### PR TITLE
check to make sure last character is line feed

### DIFF
--- a/tap_iterable/streams.py
+++ b/tap_iterable/streams.py
@@ -136,9 +136,9 @@ class Stream():
                 logger.info('wrote {} records to temp file in {} seconds'.format(count, int(write_time - start_time)))
                 with open(tf.name, 'r', encoding='utf-8') as tf_reader:
                     for line in tf_reader:
-                        # json load line with carriage return removed, but
-                        # sometimes the last line does not have a carraige
-                        # return, so check
+                        # json load line with line feed removed, but
+                        # sometimes the last line does not end with a line
+                        # feed, so check
                         if line[-1] == '\n':
                             rec = json.loads(line[:-1])
                         else:

--- a/tap_iterable/streams.py
+++ b/tap_iterable/streams.py
@@ -136,8 +136,13 @@ class Stream():
                 logger.info('wrote {} records to temp file in {} seconds'.format(count, int(write_time - start_time)))
                 with open(tf.name, 'r', encoding='utf-8') as tf_reader:
                     for line in tf_reader:
-                        # json load line with carriage return removed
-                        rec = json.loads(line[:-1])
+                        # json load line with carriage return removed, but
+                        # sometimes the last line does not have a carraige
+                        # return, so check
+                        if line[-1] == '\n':
+                            rec = json.loads(line[:-1])
+                        else:
+                            rec = json.loads(line)
                         try:
                             rec["transactionalData"] = json.loads(rec["transactionalData"])
                         except KeyError:


### PR DESCRIPTION
# Description of change
Sometimes the last line of the temp csv file we write to ended with a line feed and sometimes it didn't.  This PR addes code to check if the last line has a line feed as the last character before removing it.

# Manual QA steps
 Had cloned connection that was error'ing out, adding this code fixed the issue.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
