### PR TITLE
SUP-957: Fix users key error

### DIFF
--- a/tap_iterable/iterable.py
+++ b/tap_iterable/iterable.py
@@ -163,5 +163,5 @@ class Iterable(object):
       kwargs["startDateTime"] = start_date_time
       kwargs["endDateTime"] = self._get_end_datetime(startDateTime=start_date_time)
       def get_data():
-        return self._get("export/data.json", dataTypeName=data_type_name, **kwargs)
+        return self._get("export/data.json", dataTypeName=data_type_name, **kwargs), kwargs['endDateTime']
       yield get_data

--- a/tap_iterable/streams.py
+++ b/tap_iterable/streams.py
@@ -147,13 +147,7 @@ class Stream():
                             rec["transactionalData"] = json.loads(rec["transactionalData"])
                         except KeyError:
                             pass
-                        try:
-                            self.update_session_bookmark(rec[self.replication_key])
-                        except KeyError:
-                            logger.info('stream %s: The record did not have its intended replication key "%s"',
-                                        self.stream.tap_stream_id,
-                                        self.replication_key)
-                            self.update_session_bookmark(request_end_date)
+                        self.update_session_bookmark(rec.get(self.replication_key, request_end_date))
                         yield (self.stream, rec)
                 logger.info('Read and emitted {} records from temp file in {} seconds'.format(count, int(time.time() - write_time)))
 

--- a/tap_iterable/streams.py
+++ b/tap_iterable/streams.py
@@ -149,7 +149,7 @@ class Stream():
                             pass
                         try:
                             self.update_session_bookmark(rec[self.replication_key])
-                        except KeyError as some_error:
+                        except KeyError:
                             logger.info('stream %s: The record did not have its intended replication key "%s"',
                                         self.stream.tap_stream_id,
                                         self.replication_key)

--- a/tap_iterable/streams.py
+++ b/tap_iterable/streams.py
@@ -147,7 +147,13 @@ class Stream():
                             rec["transactionalData"] = json.loads(rec["transactionalData"])
                         except KeyError:
                             pass
-                        self.update_session_bookmark(rec[self.replication_key])
+                        try:
+                            self.update_session_bookmark(rec[self.replication_key])
+                        except KeyError as some_error:
+                            logger.info('stream %s: The record did not have its intended replication key "%s"',
+                                        self.stream.tap_stream_id,
+                                        self.replication_key)
+                            self.update_session_bookmark(request_end_date)
                         yield (self.stream, rec)
                 logger.info('Read and emitted {} records from temp file in {} seconds'.format(count, int(time.time() - write_time)))
 

--- a/tap_iterable/streams.py
+++ b/tap_iterable/streams.py
@@ -123,7 +123,7 @@ class Stream():
         bookmark = self.get_bookmark(state)
         fns = get_generator(self.data_type_name, bookmark)
         for fn in fns:
-            res = fn()
+            res, request_end_date = fn()
             count = 0
             start_time = time.time()
             with tempfile.NamedTemporaryFile() as tf:


### PR DESCRIPTION
# Description of change
https://stitchdata.atlassian.net/browse/SUP-957

I have no proof that `createdAt` is not a field on the `users` stream. I noticed though if `users` has a bookmark in state, then it will make a request with that bookmark. So this PR leverages that to keep the replication key as `createdAt`, and continue to update the bookmark to be the end date of the date window used in the request. 

# Manual QA steps
 - I ran the tap and was able to see state updates and the bookmark for `users` being used in subsequent runs
 
# Risks
 - Low since this allows the tap to run
 
# Rollback steps
 - revert this branch
