### PR TITLE
Remove key_properies from ListUsers

### DIFF
--- a/tap_iterable/streams.py
+++ b/tap_iterable/streams.py
@@ -163,6 +163,7 @@ class Lists(Stream):
 class ListUsers(Stream):
     name = "list_users"
     replication_method = "FULL_TABLE"
+    key_properties = []
 
 
 class Campaigns(Stream):


### PR DESCRIPTION
# Description of change
https://stitchdata.atlassian.net/browse/SUP-957

While working on this card, we discovered that an issue we thought we solved before. The target complains that the `ListUsers` stream is missing a key property `id` even though there is no `id` field on the records.

`grep`ing for `id` in the schemas, it appears that this is the last stream we expect to have this issue for.

# Manual QA steps
 - Tested with one state file: the tap fails without this change
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
