### PR TITLE
Made api_window_in_days as not required in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.1
+  * Made API window in days as not required in config [25](https://github.com/singer-io/tap-iterable/pull/25)
+
 ## 1.0.0
   * Beta release changes [#23](https://github.com/singer-io/tap-iterable/pull/23)
     * Discovery and API request fixes [#20](https://github.com/singer-io/tap-iterable/pull/20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.0.1
-  * Made API window in days as not required in config [25](https://github.com/singer-io/tap-iterable/pull/25)
+  * Made api_window_in_days as not required in config [25](https://github.com/singer-io/tap-iterable/pull/25)
 
 ## 1.0.0
   * Beta release changes [#23](https://github.com/singer-io/tap-iterable/pull/23)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-iterable",
-    version="1.0.0",
+    version="1.0.1",
     description="Singer.io tap for extracting Iterable data",
     author="Stitch",
     url="http://github.com/singer-io/tap-iterable",

--- a/tap_iterable/__init__.py
+++ b/tap_iterable/__init__.py
@@ -18,8 +18,7 @@ LOGGER = singer.get_logger()
 
 REQUIRED_CONFIG_KEYS = [
     "api_key",
-    "start_date",
-    "api_window_in_days"
+    "start_date"
 ]
 
 
@@ -36,9 +35,11 @@ def main():
 
     creds = {
         "start_date": parsed_args.config['start_date'],
-        "api_key": parsed_args.config['api_key'],
-        "api_window_in_days": parsed_args.config['api_window_in_days']
+        "api_key": parsed_args.config['api_key']
     }
+
+    if "api_window_in_days" in parsed_args.config.keys():
+        creds["api_window_in_days"] = parsed_args.config['api_window_in_days']
 
     client = Iterable(**creds)
     Context.config = parsed_args.config


### PR DESCRIPTION
# Description of change
API window in days should not be a required key.

# Manual QA steps
 - Tested the discovery & sync for tap.
 - Tested discovery by keeping and removing "api_window_in_days" key in config.
 
# Risks
 - Low risk
 
# Rollback steps
 - revert this branch
