### PR TITLE
Excluded unauth streams from catalog in discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.1.0
-  * Streams the credentials cannot access are excluded from the catalog during discovery. [#34](https://github.com/singer-io/tap-iterable/pull/34)
+  * Streams that the credentials cannot access are excluded from the catalog during discovery. [#34](https://github.com/singer-io/tap-iterable/pull/34)
   * Added unit tests for discovery access-check logic
 
 ## 2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.0
+  * Streams the credentials cannot access are excluded from the catalog during discovery. [#34](https://github.com/singer-io/tap-iterable/pull/34)
+  * Added unit tests for discovery access-check logic
+
 ## 2.0.0
   * Fix bookmarking issue in template stream and integration tests by improving backoff strategy [#31](https://github.com/singer-io/tap-iterable/pull/31)
   * Add logic for 5xx retry to handle server 5xx errors retries [#33](https://github.com/singer-io/tap-iterable/pull/33)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-iterable",
-    version="2.0.0",
+    version="2.1.0",
     description="Singer.io tap for extracting Iterable data",
     author="Stitch",
     url="http://github.com/singer-io/tap-iterable",

--- a/tap_iterable/discover.py
+++ b/tap_iterable/discover.py
@@ -32,8 +32,11 @@ def _apply_access_checks(client, accessible_streams: list) -> None:
     _prune_inaccessible_children(accessible_streams)
 
     if inaccessible_streams:
-        total_parent_streams = [name for name, cls in STREAMS.items() if not getattr(cls, 'parent', None)]
-        if len(inaccessible_streams) == len(total_parent_streams):
+        remaining_parents = [
+            name for name in accessible_streams
+            if not getattr(STREAMS[name], 'parent', None)
+        ]
+        if not remaining_parents:
             raise IterableForbiddenError(
                 "HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "
                 "of the streams supported by the tap. Data collection cannot be initiated due to lack of permissions."

--- a/tap_iterable/discover.py
+++ b/tap_iterable/discover.py
@@ -33,8 +33,8 @@ def _apply_access_checks(client, accessible_streams: list) -> None:
 
     if not accessible_streams:
         raise IterableForbiddenError(
-            "HTTP-error-code: 403, Error: The credentials do not have \
-                'read' access to any supported streams."
+            "HTTP-error-code: 403, Error: The credentials do not have " \
+            "'read' access to any supported streams."
         )
     elif inaccessible_streams:
         LOGGER.warning(
@@ -52,8 +52,8 @@ def _prune_inaccessible_children(accessible_streams: list) -> None:
         parent = getattr(stream_cls, 'parent', None)
         if name in accessible_streams and parent and parent not in accessible_streams:
             LOGGER.warning(
-                "Stream '%s' excluded from catalog because its parent \
-                    stream '%s' is not accessible.",
+                "Stream '%s' excluded from catalog because its parent "
+                "stream '%s' is not accessible.",
                 name, parent,
             )
             accessible_streams.remove(name)

--- a/tap_iterable/discover.py
+++ b/tap_iterable/discover.py
@@ -4,20 +4,76 @@
 
 import singer
 from tap_iterable.streams import STREAMS
+from tap_iterable.exceptions import IterableForbiddenError
+
+
+LOGGER = singer.get_logger()
+
+
+def _apply_access_checks(client, accessible_streams: list) -> None:
+    """
+    Probe each stream for read access and remove inaccessible streams
+    (and their children) from accessible_streams in place.
+    Note: check_access() always returns True for child streams, so this loop
+    effectively identifies only inaccessible parent streams by design.
+    Child stream removal is handled separately by _prune_inaccessible_children().
+    Raises IterableForbiddenError if no parent streams are accessible.
+    """
+    inaccessible_streams = [
+        stream_name
+        for stream_name, stream_cls in STREAMS.items()
+        if stream_name in accessible_streams
+        and not stream_cls(client=client).check_access()
+    ]
+
+    for stream_name in inaccessible_streams:
+        accessible_streams.remove(stream_name)
+
+    _prune_inaccessible_children(accessible_streams)
+
+    if inaccessible_streams:
+        total_parent_streams = [name for name, cls in STREAMS.items() if not getattr(cls, 'parent', None)]
+        if len(inaccessible_streams) == len(total_parent_streams):
+            raise IterableForbiddenError(
+                "HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "
+                "of the streams supported by the tap. Data collection cannot be initiated due to lack of permissions."
+            )
+        LOGGER.warning(
+            "The account credentials supplied do not have 'read' access to the following stream(s): %s. "
+            "These streams have been excluded from the catalog.",
+            ", ".join(inaccessible_streams),
+        )
+
+
+def _prune_inaccessible_children(accessible_streams: list) -> None:
+    """
+    Remove child streams from the catalog whose parent stream was excluded.
+    Mutates accessible_streams in place.
+    """
+    for name, stream_cls in list(STREAMS.items()):
+        parent = getattr(stream_cls, 'parent', None)
+        if name in accessible_streams and parent and parent not in accessible_streams:
+            LOGGER.warning(
+                "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
+                name, parent,
+            )
+            accessible_streams.remove(name)
 
 
 def discover_streams(client):
-  streams = []
+    accessible_streams = list(STREAMS.keys())
+    _apply_access_checks(client, accessible_streams)
 
-  for stream in STREAMS.values():
-    stream_client = stream(client)
-    stream_schema = stream_client.load_schema()
-    streams.append({
-      'stream': stream_client.name,
-      'tap_stream_id': stream_client.name,
-      'schema': stream_schema,
-      'metadata': stream_client.load_metadata(stream_schema)
-      }
-    )
+    streams = []
+    for stream_name in accessible_streams:
+        stream_cls = STREAMS[stream_name]
+        stream_client = stream_cls(client)
+        stream_schema = stream_client.load_schema()
+        streams.append({
+            'stream': stream_client.name,
+            'tap_stream_id': stream_client.name,
+            'schema': stream_schema,
+            'metadata': stream_client.load_metadata(stream_schema),
+        })
 
-  return streams
+    return streams

--- a/tap_iterable/discover.py
+++ b/tap_iterable/discover.py
@@ -31,19 +31,14 @@ def _apply_access_checks(client, accessible_streams: list) -> None:
 
     _prune_inaccessible_children(accessible_streams)
 
-    if inaccessible_streams:
-        remaining_parents = [
-            name for name in accessible_streams
-            if not getattr(STREAMS[name], 'parent', None)
-        ]
-        if not remaining_parents:
-            raise IterableForbiddenError(
-                "HTTP-error-code: 403, Error: The account credentials supplied do not have 'read' access to any "
-                "of the streams supported by the tap. Data collection cannot be initiated due to lack of permissions."
-            )
+    if not accessible_streams:
+        raise IterableForbiddenError(
+            "HTTP-error-code: 403, Error: The credentials do not have \
+                'read' access to any supported streams."
+        )
+    elif inaccessible_streams:
         LOGGER.warning(
-            "The account credentials supplied do not have 'read' access to the following stream(s): %s. "
-            "These streams have been excluded from the catalog.",
+            "No 'read' access to stream(s): %s. Excluded from catalog.",
             ", ".join(inaccessible_streams),
         )
 
@@ -57,7 +52,8 @@ def _prune_inaccessible_children(accessible_streams: list) -> None:
         parent = getattr(stream_cls, 'parent', None)
         if name in accessible_streams and parent and parent not in accessible_streams:
             LOGGER.warning(
-                "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
+                "Stream '%s' excluded from catalog because its parent \
+                    stream '%s' is not accessible.",
                 name, parent,
             )
             accessible_streams.remove(name)

--- a/tap_iterable/exceptions.py
+++ b/tap_iterable/exceptions.py
@@ -24,6 +24,10 @@ class IterableUnauthorizedError(IterableError):
     pass
 
 
+class IterableForbiddenError(IterableError):
+    pass
+
+
 class IterableNotAvailableError(IterableServer5xxError):
     pass
 
@@ -36,6 +40,10 @@ ERROR_CODE_EXCEPTION_MAPPING = {
     401: {
         "raise_exception": IterableUnauthorizedError,
         "message": "Invalid authorization credentials."
+    },
+    403: {
+        "raise_exception": IterableForbiddenError,
+        "message": "The account credentials supplied do not have 'read' access to the requested resource."
     },
     429: {
         "raise_exception": IterableRateLimitError,

--- a/tap_iterable/iterable.py
+++ b/tap_iterable/iterable.py
@@ -60,7 +60,9 @@ class Iterable(object):
       params[key] = value
     uri += "?{params}".format(params=urlencode(params))
     LOGGER.info("GET request to {uri}".format(uri=uri))
+
     response = requests.get(uri, stream=stream, headers=headers, params=params)
+    LOGGER.info("Response status:%s", response.status_code)
 
     raise_for_error(response)
 

--- a/tap_iterable/iterable.py
+++ b/tap_iterable/iterable.py
@@ -60,9 +60,7 @@ class Iterable(object):
       params[key] = value
     uri += "?{params}".format(params=urlencode(params))
     LOGGER.info("GET request to {uri}".format(uri=uri))
-
     response = requests.get(uri, stream=stream, headers=headers, params=params)
-    LOGGER.info("Response status:%s", response.status_code)
 
     raise_for_error(response)
 

--- a/tap_iterable/streams.py
+++ b/tap_iterable/streams.py
@@ -3,6 +3,7 @@
 # Module dependencies.
 #
 
+import io
 import os
 import json
 import datetime
@@ -14,6 +15,7 @@ from singer import metadata
 from singer import utils
 from dateutil.parser import parse
 from tap_iterable.context import Context
+from tap_iterable.exceptions import IterableForbiddenError
 import tap_iterable.helper as helper
 
 
@@ -32,10 +34,44 @@ class Stream():
     stream = None
     key_properties = KEY_PROPERTIES
     session_bookmark = None
+    check_access_endpoint = None
 
 
     def __init__(self, client=None):
         self.client = client
+
+
+    def check_access(self) -> bool:
+        """
+        Verify that the API credentials have read access to this stream.
+        Returns True if accessible, False if a 403 Forbidden error is raised.
+        Child streams always return True (access is governed by the parent check).
+        """
+        if getattr(self, 'parent', None):
+            return True
+
+        try:
+            data_type_name = getattr(self, 'data_type_name', None)
+            if data_type_name:
+                # Data export stream: probe the export endpoint with a minimal date range
+                now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                yesterday = (datetime.datetime.now() - datetime.timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S")
+                response = self.client._get(
+                    "export/data.json",
+                    dataTypeName=data_type_name,
+                    startDateTime=yesterday,
+                    endDateTime=now,
+                )
+                response.close()
+            elif self.check_access_endpoint:
+                self.client.get(self.check_access_endpoint)
+            return True
+        except IterableForbiddenError:
+            LOGGER.warning(
+                "Stream '%s' does not have read permission, excluding from catalog.",
+                self.name,
+            )
+            return False
 
 
     def is_session_bookmark_old(self, value):
@@ -91,12 +127,12 @@ class Stream():
         stream_metadata = metadata.to_map(stream_metadata)
         if self.replication_key is not None:
             stream_metadata = metadata.write(stream_metadata, ("properties", self.replication_key), "inclusion", "automatic")
-        
+
         # Check if the stream has any parent attribute
         parent_attribute = getattr(self, "parent", None)
         if parent_attribute:
             stream_metadata = metadata.write(stream_metadata, (), "parent-tap-stream-id", parent_attribute)
-        
+
         stream_metadata = metadata.to_list(stream_metadata)
         return stream_metadata
 
@@ -137,11 +173,12 @@ class Stream():
                         tf.write(b'\n')
                 # Fix for TDL-22208
                 # The expected records were getting added to temp file but observing empty file while reading
-                # Hence, added below line to move file pointer to the beginning of a file 
+                # Hence, added below line to move file pointer to the beginning of a file
                 tf.seek(0)
                 write_time = time.time()
                 LOGGER.info('wrote {} records to temp file in {} seconds'.format(count, int(write_time - start_time)))
-                with open(tf.name, 'r', encoding='utf-8') as tf_reader:
+                tf_reader = io.TextIOWrapper(tf, encoding='utf-8')
+                try:
                     for line in tf_reader:
                         # json load line with line feed removed, but
                         # sometimes the last line does not end with a line
@@ -156,10 +193,12 @@ class Stream():
                             pass
                         self.update_session_bookmark(rec.get(self.replication_key, request_end_date))
                         yield (self.stream, rec)
-                LOGGER.info('Read and emitted {} records from temp file in {} seconds'.format(count, int(time.time() - write_time)))
+                    LOGGER.info('Read and emitted {} records from temp file in {} seconds'.format(count, int(time.time() - write_time)))
+                finally:
+                    tf_reader.detach()  # detach so NamedTemporaryFile can still close the underlying handle
 
             if not self.session_bookmark and bookmark :
-                self.session_bookmark = bookmark 
+                self.session_bookmark = bookmark
             self.update_bookmark(state, self.session_bookmark)
             singer.write_state(state)
 
@@ -167,6 +206,7 @@ class Stream():
 class Lists(Stream):
     name = "lists"
     replication_method = "FULL_TABLE"
+    check_access_endpoint = "lists"
 
 
 class ListUsers(Stream):
@@ -180,16 +220,19 @@ class Campaigns(Stream):
     name = "campaigns"
     replication_method = "INCREMENTAL"
     replication_key = "updatedAt"
+    check_access_endpoint = "campaigns"
 
 
 class Channels(Stream):
     name = "channels"
     replication_method = "FULL_TABLE"
+    check_access_endpoint = "channels"
 
 
 class MessageTypes(Stream):
     name = "message_types"
     replication_method = "FULL_TABLE"
+    check_access_endpoint = "messageTypes"
 
 
 class Templates(Stream):
@@ -197,12 +240,14 @@ class Templates(Stream):
     replication_method = "INCREMENTAL"
     replication_key = "updatedAt"
     key_properties = ["templateId"]
+    check_access_endpoint = "templates"
 
 
 class Metadata(Stream):
     name = "metadata"
     replication_method = "FULL_TABLE"
     key_properties = [ "key" ]
+    check_access_endpoint = "metadata"
 
 
 class EmailBounce(Stream):

--- a/tap_iterable/streams.py
+++ b/tap_iterable/streams.py
@@ -64,7 +64,8 @@ class Stream():
                 )
                 response.close()
             elif self.check_access_endpoint:
-                self.client.get(self.check_access_endpoint)
+                response = self.client._get(self.check_access_endpoint, stream=True)
+                response.close()
             return True
         except IterableForbiddenError:
             LOGGER.warning(
@@ -196,7 +197,7 @@ class Stream():
                     LOGGER.info('Read and emitted {} records from temp file in {} seconds'.format(count, int(time.time() - write_time)))
                 finally:
                     tf_reader.detach()  # detach so NamedTemporaryFile can still close the underlying handle
-
+                    tf_reader.close()
             if not self.session_bookmark and bookmark :
                 self.session_bookmark = bookmark
             self.update_bookmark(state, self.session_bookmark)

--- a/tap_iterable/streams.py
+++ b/tap_iterable/streams.py
@@ -52,14 +52,14 @@ class Stream():
         try:
             data_type_name = getattr(self, 'data_type_name', None)
             if data_type_name:
-                # Probe with a 1-hour window — just enough to verify access
+                # Probe with a 1-minute window — just enough to verify access
                 now = datetime.datetime.now()
-                one_hour_ago = (now - datetime.timedelta(hours=1)).strftime("%Y-%m-%d %H:%M:%S")
+                one_minute_ago = (now - datetime.timedelta(minutes=1)).strftime("%Y-%m-%d %H:%M:%S")
                 now = now.strftime("%Y-%m-%d %H:%M:%S")
                 response = self.client._get(
                     "export/data.json",
                     dataTypeName=data_type_name,
-                    startDateTime=one_hour_ago,
+                    startDateTime=one_minute_ago,
                     endDateTime=now,
                 )
                 response.close()
@@ -69,9 +69,9 @@ class Stream():
             return True
         except IterableForbiddenError as exc:
             LOGGER.warning(
-                "Permission Error: Stream '%s' %s. Excluding from catalog.",
+                "Unauthorized Stream: %s, excluding from catalog. HTTP-Error-Message: '%s'",
                 self.name,
-                exc,
+                str(exc),
             )
             return False
 
@@ -179,24 +179,23 @@ class Stream():
                 tf.seek(0)
                 write_time = time.time()
                 LOGGER.info('wrote {} records to temp file in {} seconds'.format(count, int(write_time - start_time)))
-                for raw_line in tf:
-                    line = raw_line.decode('utf-8')
-                    # json load line with line feed removed, but
-                    # sometimes the last line does not end with a line
-                    # feed, so check
-                    if line[-1] == '\n':
-                        rec = json.loads(line[:-1])
-                    else:
-                        rec = json.loads(line)
-                    try:
-                        rec["transactionalData"] = json.loads(rec["transactionalData"])
-                    except KeyError:
-                        # transactionalData is optional and only present on some email_send records;
-                        # skip the JSON deserialisation if the field is absent.
-                        pass
-                    self.update_session_bookmark(rec.get(self.replication_key, request_end_date))
-                    yield (self.stream, rec)
+                with open(tf.name, 'r', encoding='utf-8') as tf_reader:
+                    for line in tf_reader:
+                        # json load line with line feed removed, but
+                        # sometimes the last line does not end with a line
+                        # feed, so check
+                        if line[-1] == '\n':
+                            rec = json.loads(line[:-1])
+                        else:
+                            rec = json.loads(line)
+                        try:
+                            rec["transactionalData"] = json.loads(rec["transactionalData"])
+                        except KeyError:
+                            pass
+                        self.update_session_bookmark(rec.get(self.replication_key, request_end_date))
+                        yield (self.stream, rec)
                 LOGGER.info('Read and emitted {} records from temp file in {} seconds'.format(count, int(time.time() - write_time)))
+
             if not self.session_bookmark and bookmark :
                 self.session_bookmark = bookmark
             self.update_bookmark(state, self.session_bookmark)

--- a/tap_iterable/streams.py
+++ b/tap_iterable/streams.py
@@ -3,7 +3,6 @@
 # Module dependencies.
 #
 
-import io
 import os
 import json
 import datetime
@@ -178,26 +177,24 @@ class Stream():
                 tf.seek(0)
                 write_time = time.time()
                 LOGGER.info('wrote {} records to temp file in {} seconds'.format(count, int(write_time - start_time)))
-                tf_reader = io.TextIOWrapper(tf, encoding='utf-8')
-                try:
-                    for line in tf_reader:
-                        # json load line with line feed removed, but
-                        # sometimes the last line does not end with a line
-                        # feed, so check
-                        if line[-1] == '\n':
-                            rec = json.loads(line[:-1])
-                        else:
-                            rec = json.loads(line)
-                        try:
-                            rec["transactionalData"] = json.loads(rec["transactionalData"])
-                        except KeyError:
-                            pass
-                        self.update_session_bookmark(rec.get(self.replication_key, request_end_date))
-                        yield (self.stream, rec)
-                    LOGGER.info('Read and emitted {} records from temp file in {} seconds'.format(count, int(time.time() - write_time)))
-                finally:
-                    tf_reader.detach()  # detach so NamedTemporaryFile can still close the underlying handle
-                    tf_reader.close()
+                for raw_line in tf:
+                    line = raw_line.decode('utf-8')
+                    # json load line with line feed removed, but
+                    # sometimes the last line does not end with a line
+                    # feed, so check
+                    if line[-1] == '\n':
+                        rec = json.loads(line[:-1])
+                    else:
+                        rec = json.loads(line)
+                    try:
+                        rec["transactionalData"] = json.loads(rec["transactionalData"])
+                    except KeyError:
+                        # transactionalData is optional and only present on some email_send records;
+                        # skip the JSON deserialisation if the field is absent.
+                        pass
+                    self.update_session_bookmark(rec.get(self.replication_key, request_end_date))
+                    yield (self.stream, rec)
+                LOGGER.info('Read and emitted {} records from temp file in {} seconds'.format(count, int(time.time() - write_time)))
             if not self.session_bookmark and bookmark :
                 self.session_bookmark = bookmark
             self.update_bookmark(state, self.session_bookmark)

--- a/tap_iterable/streams.py
+++ b/tap_iterable/streams.py
@@ -52,13 +52,14 @@ class Stream():
         try:
             data_type_name = getattr(self, 'data_type_name', None)
             if data_type_name:
-                # Data export stream: probe the export endpoint with a minimal date range
-                now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-                yesterday = (datetime.datetime.now() - datetime.timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S")
+                # Probe with a 1-hour window — just enough to verify access
+                now = datetime.datetime.now()
+                one_hour_ago = (now - datetime.timedelta(hours=1)).strftime("%Y-%m-%d %H:%M:%S")
+                now = now.strftime("%Y-%m-%d %H:%M:%S")
                 response = self.client._get(
                     "export/data.json",
                     dataTypeName=data_type_name,
-                    startDateTime=yesterday,
+                    startDateTime=one_hour_ago,
                     endDateTime=now,
                 )
                 response.close()
@@ -66,10 +67,11 @@ class Stream():
                 response = self.client._get(self.check_access_endpoint, stream=True)
                 response.close()
             return True
-        except IterableForbiddenError:
+        except IterableForbiddenError as exc:
             LOGGER.warning(
-                "Stream '%s' does not have read permission, excluding from catalog.",
+                "Permission Error: Stream '%s' %s. Excluding from catalog.",
                 self.name,
+                exc,
             )
             return False
 

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -1,13 +1,54 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+import requests
+
 from tap_iterable.discover import (
     _apply_access_checks,
     _prune_inaccessible_children,
     discover_streams,
 )
-from tap_iterable.exceptions import IterableForbiddenError
+from tap_iterable.exceptions import (
+    IterableForbiddenError,
+    raise_for_error,
+)
 from tap_iterable.streams import STREAMS
+
+
+class MockResponse:
+    """Minimal requests.Response stand-in for raise_for_error tests."""
+
+    def __init__(self, status_code, json_body=None):
+        self.status_code = status_code
+        self._json = json_body or {}
+
+    def raise_for_status(self):
+        raise requests.HTTPError("mock error")
+
+    def json(self):
+        return self._json
+
+
+class TestRaiseForError403(unittest.TestCase):
+    """Verify that a 403 response raises IterableForbiddenError (not retried by backoff)."""
+
+    def test_403_raises_iterable_forbidden_error(self):
+        response = MockResponse(403)
+        with self.assertRaises(IterableForbiddenError) as ctx:
+            raise_for_error(response)
+        self.assertIn("403", str(ctx.exception))
+
+    def test_403_uses_default_message_when_body_has_no_message(self):
+        response = MockResponse(403, json_body={})
+        with self.assertRaises(IterableForbiddenError) as ctx:
+            raise_for_error(response)
+        self.assertIn("read", str(ctx.exception))
+
+    def test_403_uses_api_message_when_present(self):
+        response = MockResponse(403, json_body={"message": "Forbidden by policy"})
+        with self.assertRaises(IterableForbiddenError) as ctx:
+            raise_for_error(response)
+        self.assertIn("Forbidden by policy", str(ctx.exception))
 
 
 class TestCheckAccess(unittest.TestCase):
@@ -26,16 +67,19 @@ class TestCheckAccess(unittest.TestCase):
         """REST streams return True when the API call succeeds."""
         from tap_iterable.streams import Channels
         client = self._make_client()
+        mock_response = MagicMock()
+        client._get.return_value = mock_response
         stream = Channels(client=client)
         result = stream.check_access()
-        client.get.assert_called_once_with("channels")
+        client._get.assert_called_once_with("channels", stream=True)
+        mock_response.close.assert_called_once()
         self.assertTrue(result)
 
     def test_check_access_returns_false_on_forbidden_rest(self):
         """REST streams return False when the API call raises IterableForbiddenError."""
         from tap_iterable.streams import Channels
         client = self._make_client()
-        client.get.side_effect = IterableForbiddenError("403 Forbidden")
+        client._get.side_effect = IterableForbiddenError("403 Forbidden")
         stream = Channels(client=client)
         result = stream.check_access()
         self.assertFalse(result)

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -1,0 +1,206 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tap_iterable.discover import (
+    _apply_access_checks,
+    _prune_inaccessible_children,
+    discover_streams,
+)
+from tap_iterable.exceptions import IterableForbiddenError
+from tap_iterable.streams import STREAMS
+
+
+class TestCheckAccess(unittest.TestCase):
+    """Unit tests for Stream.check_access()."""
+
+    def _make_client(self):
+        return MagicMock()
+
+    def test_check_access_returns_true_for_child_stream(self):
+        """Child streams (with a parent attribute) always return True."""
+        from tap_iterable.streams import ListUsers
+        stream = ListUsers(client=self._make_client())
+        self.assertTrue(stream.check_access())
+
+    def test_check_access_returns_true_when_rest_endpoint_ok(self):
+        """REST streams return True when the API call succeeds."""
+        from tap_iterable.streams import Channels
+        client = self._make_client()
+        stream = Channels(client=client)
+        result = stream.check_access()
+        client.get.assert_called_once_with("channels")
+        self.assertTrue(result)
+
+    def test_check_access_returns_false_on_forbidden_rest(self):
+        """REST streams return False when the API call raises IterableForbiddenError."""
+        from tap_iterable.streams import Channels
+        client = self._make_client()
+        client.get.side_effect = IterableForbiddenError("403 Forbidden")
+        stream = Channels(client=client)
+        result = stream.check_access()
+        self.assertFalse(result)
+
+    def test_check_access_returns_true_for_export_stream_when_ok(self):
+        """Data export streams return True when the export endpoint responds successfully."""
+        from tap_iterable.streams import EmailBounce
+        client = self._make_client()
+        mock_response = MagicMock()
+        client._get.return_value = mock_response
+        stream = EmailBounce(client=client)
+        result = stream.check_access()
+        self.assertTrue(result)
+        mock_response.close.assert_called_once()
+
+    def test_check_access_returns_false_on_forbidden_export(self):
+        """Data export streams return False when the export endpoint returns 403."""
+        from tap_iterable.streams import EmailBounce
+        client = self._make_client()
+        client._get.side_effect = IterableForbiddenError("403 Forbidden")
+        stream = EmailBounce(client=client)
+        result = stream.check_access()
+        self.assertFalse(result)
+
+    def test_check_access_returns_true_no_endpoint(self):
+        """Streams with no endpoint and no data_type_name always return True."""
+        from tap_iterable.streams import Stream
+        stream = Stream(client=self._make_client())
+        result = stream.check_access()
+        self.assertTrue(result)
+
+
+class TestPruneInaccessibleChildren(unittest.TestCase):
+    """Unit tests for _prune_inaccessible_children()."""
+
+    def test_child_remains_when_parent_present(self):
+        """list_users stays in the catalog when lists is accessible."""
+        accessible = ["lists", "list_users", "channels"]
+        _prune_inaccessible_children(accessible)
+        self.assertIn("list_users", accessible)
+
+    def test_child_removed_when_parent_absent(self):
+        """list_users is removed when lists is not accessible."""
+        accessible = ["list_users", "channels", "campaigns"]
+        _prune_inaccessible_children(accessible)
+        self.assertNotIn("list_users", accessible)
+
+    def test_non_child_streams_unaffected(self):
+        """Streams without a parent are not removed by pruning."""
+        accessible = ["channels", "campaigns", "metadata"]
+        _prune_inaccessible_children(accessible)
+        self.assertEqual(["channels", "campaigns", "metadata"], accessible)
+
+
+class TestApplyAccessChecks(unittest.TestCase):
+    """Unit tests for _apply_access_checks()."""
+
+    def _mock_client(self):
+        return MagicMock()
+
+    def test_all_streams_accessible(self):
+        """No streams are removed when all check_access() calls return True."""
+        client = self._mock_client()
+        accessible = list(STREAMS.keys())
+
+        with patch("tap_iterable.streams.Stream.check_access", return_value=True):
+            _apply_access_checks(client, accessible)
+
+        self.assertEqual(sorted(accessible), sorted(STREAMS.keys()))
+
+    def test_inaccessible_stream_removed(self):
+        """A stream whose check_access() returns False is removed from the catalog."""
+        client = self._mock_client()
+        accessible = list(STREAMS.keys())
+
+        def fake_check_access(self):
+            if self.name == "channels":
+                return False
+            return True
+
+        with patch("tap_iterable.streams.Stream.check_access", fake_check_access):
+            _apply_access_checks(client, accessible)
+
+        self.assertNotIn("channels", accessible)
+
+    def test_child_removed_when_parent_inaccessible(self):
+        """list_users is removed when lists is inaccessible."""
+        client = self._mock_client()
+        accessible = list(STREAMS.keys())
+
+        def fake_check_access(self):
+            if self.name == "lists":
+                return False
+            return True
+
+        with patch("tap_iterable.streams.Stream.check_access", fake_check_access):
+            _apply_access_checks(client, accessible)
+
+        self.assertNotIn("lists", accessible)
+        self.assertNotIn("list_users", accessible)
+
+    def test_all_parent_streams_inaccessible_raises(self):
+        """IterableForbiddenError is raised when every parent stream is inaccessible."""
+        client = self._mock_client()
+        accessible = list(STREAMS.keys())
+
+        def fake_check_access(self):
+            # Child streams return True; all parents return False
+            if getattr(self, "parent", None):
+                return True
+            return False
+
+        with patch("tap_iterable.streams.Stream.check_access", fake_check_access):
+            with self.assertRaises(IterableForbiddenError):
+                _apply_access_checks(client, accessible)
+
+    def test_partial_inaccessible_does_not_raise(self):
+        """No exception raised when at least one parent stream is accessible."""
+        client = self._mock_client()
+        accessible = list(STREAMS.keys())
+
+        parent_streams = [name for name, cls in STREAMS.items() if not getattr(cls, "parent", None)]
+        # Make only the first parent inaccessible, rest accessible
+        first_parent = parent_streams[0]
+
+        def fake_check_access(self):
+            if self.name == first_parent:
+                return False
+            return True
+
+        with patch("tap_iterable.streams.Stream.check_access", fake_check_access):
+            # Should not raise
+            _apply_access_checks(client, accessible)
+
+        self.assertNotIn(first_parent, accessible)
+
+
+class TestDiscoverStreams(unittest.TestCase):
+    """Integration-style unit tests for discover_streams()."""
+
+    def test_discover_streams_returns_all_when_accessible(self):
+        """discover_streams() returns an entry for each stream when all are accessible."""
+        client = MagicMock()
+
+        with patch("tap_iterable.streams.Stream.check_access", return_value=True), \
+             patch("tap_iterable.streams.Stream.load_schema", return_value={}), \
+             patch("tap_iterable.streams.Stream.load_metadata", return_value=[]):
+            result = discover_streams(client)
+
+        self.assertEqual(len(result), len(STREAMS))
+        stream_names = {s["stream"] for s in result}
+        self.assertEqual(stream_names, {cls.name for cls in STREAMS.values()})
+
+    def test_discover_streams_excludes_inaccessible(self):
+        """discover_streams() omits a stream that check_access() rejects."""
+        client = MagicMock()
+
+        def fake_check_access(self):
+            return self.name != "channels"
+
+        with patch("tap_iterable.streams.Stream.check_access", fake_check_access), \
+             patch("tap_iterable.streams.Stream.load_schema", return_value={}), \
+             patch("tap_iterable.streams.Stream.load_metadata", return_value=[]):
+            result = discover_streams(client)
+
+        stream_names = [s["stream"] for s in result]
+        self.assertNotIn("channels", stream_names)
+        self.assertEqual(len(result), len(STREAMS) - 1)

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -216,6 +216,28 @@ class TestApplyAccessChecks(unittest.TestCase):
 
         self.assertNotIn(first_parent, accessible)
 
+    def test_all_inaccessible_error_message(self):
+        client = MagicMock()
+        accessible = list(STREAMS.keys())
+        with patch('tap_iterable.streams.Stream.check_access', return_value=False):
+            with self.assertRaises(IterableForbiddenError) as ctx:
+                _apply_access_checks(client, accessible)
+        self.assertIn('403', str(ctx.exception))
+        self.assertIn("do not have 'read' access to any supported streams", str(ctx.exception))
+
+    def test_all_inaccessible_exact_error_message(self):
+        """Validate the exact error message raised when no streams are accessible."""
+        client = MagicMock()
+        accessible = list(STREAMS.keys())
+        expected_message = (
+            "HTTP-error-code: 403, Error: The credentials "
+            "do not have 'read' access to any supported streams."
+        )
+        with patch('tap_iterable.streams.Stream.check_access', return_value=False):
+            with self.assertRaises(IterableForbiddenError) as ctx:
+                _apply_access_checks(client, accessible)
+        self.assertEqual(expected_message, str(ctx.exception))
+
 
 class TestDiscoverStreams(unittest.TestCase):
     """Integration-style unit tests for discover_streams()."""


### PR DESCRIPTION
# Description of change
PR includes: [SAC-30932](https://qlik-dev.atlassian.net/browse/SAC-30932)
  - Add check_access() to Stream.
  - Add _apply_access_checks() and _prune_inaccessible_children() to discover.py.
  - Raise IterableForbiddenError if no parent streams are accessible at all.
  - Add unit tests for access-check in test_discovery.py.
  - Bump version to 2.1.0.

# Manual QA steps
 - [x]  Discovery: Running
 - [x]  Sync: Running
 - [x]  Unit Tests: Running
 - [x]  Integration test: Running
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
